### PR TITLE
use limited buffer to save pptx incase of large size image as input

### DIFF
--- a/lib/pptx_masher/quick_zip.rb
+++ b/lib/pptx_masher/quick_zip.rb
@@ -22,7 +22,18 @@ module PPTXMasher
         src_files.each do |path|
           zip_path = path.gsub "#{src}/", ''
           next if zip_path == "." || zip_path == ".."
-          zip_file.add(zip_path, path)
+          if File.directory?(path)
+            zip_file.mkdir(zip_path)
+          else
+            zip_file.get_output_stream zip_path do |io|
+              File.open(path, 'rb') do |src_file|
+                buffer = ''
+                while src_file.read(1048576, buffer) do
+                  io.puts buffer
+                end
+              end
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
We can use the script added in https://github.com/danielfone/gomedia-ooh-manager/pull/91 to see the difference, after having uploaded a 12mb jpeg photo (likely a panorama shot taken by our cellphone) as the image of `Panel.last`, we can run that script to see the difference, 

before the patch: (taken consideration of GC only the first line should be trusted)

```
50444kB cosumed (now 147mB)
15792kB cosumed (now 132mB)
27944kB cosumed (now 146mB)
18272kB cosumed (now 151mB)
26412kB cosumed (now 150mB)
50444kB cosumed
15792kB cosumed
27944kB cosumed
18272kB cosumed
26412kB cosumed
sum: 135mB
```

after comment the line (creating empty zip): https://github.com/danielfone/pptx_masher/blob/master/lib/pptx_masher/quick_zip.rb#L25

```
28212kB cosumed (now 126mB)
2720kB cosumed (now 129mB)
1044kB cosumed (now 130mB)
344kB cosumed (now 130mB)
1392kB cosumed (now 132mB)
28212kB cosumed
2720kB cosumed
1044kB cosumed
344kB cosumed
1392kB cosumed
sum: 32mB
```

after the patch:

```
34008kB cosumed (now 133mB)
18368kB cosumed (now 139mB)
30936kB cosumed (now 156mB)
34876kB cosumed (now 162mB)
35016kB cosumed (now 163mB)
34008kB cosumed
18368kB cosumed
30936kB cosumed
34876kB cosumed
35016kB cosumed
sum: 149mB
```
